### PR TITLE
Fix broken images and formatting in emails

### DIFF
--- a/app/mailers/thing_mailer.rb
+++ b/app/mailers/thing_mailer.rb
@@ -4,7 +4,6 @@ class ThingMailer < ApplicationMailer
     @user = thing.user
 
     attachments.inline['adopt-a-drain.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}")
-    attachments.inline['adoptadrain-event.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/adoptadrain-event.png'}")
     attachments.inline['facebook.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}")
     attachments.inline['twitter.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}")
     attachments.inline['instagram.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}")
@@ -15,14 +14,21 @@ class ThingMailer < ApplicationMailer
   def second_adoption_confirmation(thing)
     @thing = thing
     @user = thing.user
+
+    attachments.inline['adopt-a-drain.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}")
+    attachments.inline['facebook.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}")
+    attachments.inline['twitter.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}")
+    attachments.inline['instagram.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}")
+
     mail(to: @user.email, subject: ["Thanks for adopting another drain, #{@user.name.split.first}!"])
   end
 
-  def third_adoption_confirmation(thing)
-    @thing = thing
-    @user = thing.user
-    mail(to: @user.email, subject: ["We really do love you, #{@user.name.split.first}!"])
-  end
+  # This email is unused at this time
+  # def third_adoption_confirmation(thing)
+  #   @thing = thing
+  #   @user = thing.user
+  #   mail(to: @user.email, subject: ["We really do love you, #{@user.name.split.first}!"])
+  # end
 
   def reminder(thing)
     @thing = thing

--- a/app/mailers/thing_mailer.rb
+++ b/app/mailers/thing_mailer.rb
@@ -3,6 +3,12 @@ class ThingMailer < ApplicationMailer
     @thing = thing
     @user = thing.user
 
+    attachments.inline['adopt-a-drain.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}")
+    attachments.inline['adoptadrain-event.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/adoptadrain-event.png'}")
+    attachments.inline['facebook.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}")
+    attachments.inline['twitter.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}")
+    attachments.inline['instagram.png'] = File.read("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}")
+
     mail(to: @user.email, subject: ["Thanks for adopting a drain, #{@user.name.split.first}!"])
   end
 

--- a/app/views/thing_mailer/_email_footer.html.erb
+++ b/app/views/thing_mailer/_email_footer.html.erb
@@ -1,0 +1,19 @@
+<p>
+<em>
+  Remember, GVMC & Sponsoring Jurisdictions won't be held responsible for anything that
+  happens to you or others in service of maintaining your drain. Please be careful!
+</em>
+</p>
+
+<p style="font-size: 11px;">
+If you move or are no longer able to tend to your drain, please abandon it on
+<a href="http://www.adoptadrain-lgrow.org">www.adoptadrain-lgrow.org</a>.
+</p>
+
+<p style="font-size: 11px;">
+If you would like to receive quarterly LGROW emails, please sign up <a href="https://www.lgrow.org">HERE</a>.
+</p>
+
+<p style="font-size: 11px;">
+Thank you.<br/><br/>
+</p>

--- a/app/views/thing_mailer/_logo_header.html.erb
+++ b/app/views/thing_mailer/_logo_header.html.erb
@@ -1,0 +1,11 @@
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr>
+  <td>
+    <%= image_tag attachments['adopt-a-drain.png'].url, 
+        :alt => "grbwater adopt-a-drain logo", 
+        :title => "grbwater adopt-a-drain logo", 
+        :style => "max-width:300px"
+    %>
+  </td>
+</tr>
+</table>

--- a/app/views/thing_mailer/_signature.html.erb
+++ b/app/views/thing_mailer/_signature.html.erb
@@ -1,0 +1,12 @@
+<p>
+    Sincerely,
+  </p>
+  <p>
+    The LGROW Team
+    <br /><br />
+    Keep your Lakes Great and your River Grand
+    <br />
+    ph. 616-776-7605
+    <br />
+    <a href="mailto:adoptadrain@lgrow.org">adoptadrain@lgrow.org</a>
+  </p>

--- a/app/views/thing_mailer/_social_media.html.erb
+++ b/app/views/thing_mailer/_social_media.html.erb
@@ -1,0 +1,13 @@
+<p>
+    <a href="https://www.facebook.com/LGROW.org" style="text-decoration:none !important;">
+    <%= image_tag attachments['facebook.png'].url, :alt => "grbwater facebook", :title => "grbwater facebook" %>
+    </a>
+    &nbsp;
+    <a href="https://www.instagram.com/lgrow_org/" style="text-decoration:none !important;">
+    <%= image_tag attachments['instagram.png'].url, :alt => "grbwater instagram", :title => "grbwater instagram" %>
+    </a>
+    &nbsp;
+    <a href="https://twitter.com/LGROW_GVMC" style="text-decoration:none !important;">
+    <%= image_tag attachments['twitter.png'].url, :alt => "grbwater twitter", :title => "grbwater twitter" %>
+    </a>
+</p>

--- a/app/views/thing_mailer/first_adoption_confirmation.html.erb
+++ b/app/views/thing_mailer/first_adoption_confirmation.html.erb
@@ -2,7 +2,8 @@
   <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
       <td style="text-align: center;">
-        <%= image_tag image_url("logos/adopt-a-drain.png"), :alt => "grbwater adopt-a-drain logo", :title => "grbwater adopt-a-drain logo" %>
+        <%= image_tag attachments['adopt-a-drain.png'].url, :alt => "grbwater adopt-a-drain logo", :title => "grbwater adopt-a-drain logo", :style => "max-width:800px"
+        %>
       </td>
     </tr>
   </table>
@@ -65,7 +66,7 @@
   <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
       <td style="text-align: center;">
-        <%= image_tag image_url("adoptadrain-event.png"), :alt => "adopt-a-drain event", :title => "adopt-a-drain event" %>
+        <%= image_tag attachments['adoptadrain-event.png'].url, :alt => "adopt-a-drain event", :title => "adopt-a-drain event" %>
         <p style="font-style: italic; font-size: 10px;">
           Adopt a Drain VIP event
         </p>
@@ -110,7 +111,17 @@
   <p style="font-style: italic; font-size: 11px;">
    If you would like to receive quarterly LGROW emails, please sign up <a href="https://www.lgrow.org">HERE</a>.
   </p>
-
+  <a href="https://www.facebook.com/LGROW.org" style="text-decoration:none !important;">
+    <%= image_tag attachments['facebook.png'].url, :alt => "grbwater facebook", :title => "grbwater facebook" %>
+  </a>
+  &nbsp;
+  <a href="https://twitter.com/LGROW_GVMC" style="text-decoration:none !important;">
+    <%= image_tag attachments['twitter.png'].url, :alt => "grbwater twitter", :title => "grbwater twitter" %>
+  </a>
+  &nbsp;
+  <a href="https://www.instagram.com/lgrow_org/" style="text-decoration:none !important;">
+    <%= image_tag attachments['instagram.png'].url, :alt => "grbwater instagram", :title => "grbwater instagram" %>
+  </a>
 
   <p style="font-style: italic; font-size: 11px;">
    Thank you.

--- a/app/views/thing_mailer/first_adoption_confirmation.html.erb
+++ b/app/views/thing_mailer/first_adoption_confirmation.html.erb
@@ -1,12 +1,6 @@
 <table width="100%" border="0" cellspacing="0" cellpadding="0" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><tr><td>
-  <table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-      <td style="text-align: center;">
-        <%= image_tag attachments['adopt-a-drain.png'].url, :alt => "grbwater adopt-a-drain logo", :title => "grbwater adopt-a-drain logo", :style => "max-width:800px"
-        %>
-      </td>
-    </tr>
-  </table>
+
+  <%= render :partial => 'logo_header' %>
 
   <p>
     Dear <%= @user.name.split.first %>,
@@ -18,114 +12,61 @@
     to protect the environment, manage stormwater, and minimize flooding.
   </p>
 
-  <h2 style="font-size: 1.05em">How to Care For Your Adopted Drain</h2>
+  <h2 style="font-size: 1.05em; margin-top: 30px;">How to Care For Your Adopted Drain</h2>
 
   <ul>
-    <li>
+    <li style="margin-bottom: 10px;">
       Check the weather report weekly. If possible, clear leaves and debris off
       the drain before it starts raining and shovel snow off the drain in winter.
     </li>
-    <li>
+    <li style="margin-bottom: 10px;">
       Remove leaves, other natural materials, and trash. Compost if possible or
       dispose of them according to your community’s guidelines.
     </li>
-    <li>
+    <li style="margin-bottom: 10px;">
       Clear about 10 feet on both sides of the drain.
     </li>
-    <li>
+    <li style="margin-bottom: 10px;">
       Did you find medical waste or needles? Construction debris? Toxic materials?
       Follow your community’s instructions for disposal guideline.
       For more information, click <a href="https://www.lgrow.org/disposal">HERE</a>
     </li>
   </ul>
 
-  <h2 style="font-size: 1.05em">Drain Cleaning Safety Tips</h2>
+  <h2 style="font-size: 1.05em; margin-top: 30px;">Drain Cleaning Safety Tips</h2>
 
   <ul>
-    <li>
-      Never try to lift/remove the drain grate.
+    <li style="margin-bottom: 10px;">
+      Please stay out of the street as much as possible. 
+      Place yourself in the right of way (the area between the 
+      sidewalk and the street) to clear the drain.
     </li>
-    <li>
-      Clear from the sidewalk or side of the road, not the street.
-    </li>
-    <li>
-      Wear reflective clothing so vehicles can see you.
-    </li>
-    <li>
+    <li style="margin-bottom: 10px;">
       Always wear gloves and be careful of sharp objects!
     </li>
-    <li>
+    <li style="margin-bottom: 10px;">
       Use a rake, broom, or shovel if possible.
     </li>
-    <li>
+    <li style="margin-bottom: 10px;">
+      Never try to lift/remove the drain grate.
+    </li>
+    <li style="margin-bottom: 10px;">
+      Wear reflective clothing so vehicles can see you.
+    </li>
+    <li style="margin-bottom: 10px;">
       Dispose of waste appropriately. Visit <a href="https://www.lgrow.org/disposal">www.LGROW.org</a> to find out
       how to properly dispose of yard and household hazardous wastes in your community.
     </li>
   </ul>
 
-  <table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-      <td style="text-align: center;">
-        <%= image_tag attachments['adoptadrain-event.png'].url, :alt => "adopt-a-drain event", :title => "adopt-a-drain event" %>
-        <p style="font-style: italic; font-size: 10px;">
-          Adopt a Drain VIP event
-        </p>
-      </td>
-    </tr>
-  </table>
-
-  <p>
-    Keep an eye out for an email invitation to attend one of our VIP Volunteer
-    events, where you will be able to receive drain cleaning tools and
-    training. We also send periodic email reminders to clear your drains.
-  </p>
-
-  <p>
+  <p style="margin-top: 30px">
     Thanks again, <%= @user.name.split.first %>, for adopting a drain in the Lower Grand River Watershed. When each of us helps out a little, it makes a big difference!
   </p>
 
-  <p>
-    Sincerely,
-  </p>
-  <p>
-    The LGROW Team
-    <br />
-    Keep your Lakes Great and your River Grand
-    ph. 616-776-7605
+  <%= render :partial => 'signature' %>  
 
-    <a href="mailto:adoptadrain@lgrow.org">adoptadrain@lgrow.org</a>
-  </p>
+  <%= render :partial => 'email_footer' %>
 
-  <p>
-    <em>
-      Remember, GVMC & Sponsoring Jurisdictions won't be held responsible for anything that
-      happens to you or others in service of maintaining your drain. Please be careful!
-    </em>
-  </p>
-
-  <p style="font-style: italic; font-size: 11px;">
-    If you move or are no longer able to tend to your drain, please abandon it on
-    <a href="http://www.adoptadrain-lgrow.org">www.adoptadrain-lgrow.org</a>. Thank you.
-  </p>
-
-  <p style="font-style: italic; font-size: 11px;">
-   If you would like to receive quarterly LGROW emails, please sign up <a href="https://www.lgrow.org">HERE</a>.
-  </p>
-  <a href="https://www.facebook.com/LGROW.org" style="text-decoration:none !important;">
-    <%= image_tag attachments['facebook.png'].url, :alt => "grbwater facebook", :title => "grbwater facebook" %>
-  </a>
-  &nbsp;
-  <a href="https://twitter.com/LGROW_GVMC" style="text-decoration:none !important;">
-    <%= image_tag attachments['twitter.png'].url, :alt => "grbwater twitter", :title => "grbwater twitter" %>
-  </a>
-  &nbsp;
-  <a href="https://www.instagram.com/lgrow_org/" style="text-decoration:none !important;">
-    <%= image_tag attachments['instagram.png'].url, :alt => "grbwater instagram", :title => "grbwater instagram" %>
-  </a>
-
-  <p style="font-style: italic; font-size: 11px;">
-   Thank you.
-  </p>
-
+  <%= render :partial => 'social_media' %>
 
 </td></tr></table>

--- a/app/views/thing_mailer/second_adoption_confirmation.html.erb
+++ b/app/views/thing_mailer/second_adoption_confirmation.html.erb
@@ -1,11 +1,6 @@
 <table width="100%" border="0" cellspacing="0" cellpadding="0" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><tr><td>
-  <table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-      <td style="text-align: center;">
-        <%= image_tag image_url("logos/adopt-a-drain.png"), :alt => "grbwater adopt-a-drain logo", :title => "grbwater adopt-a-drain logo" %>
-      </td>
-    </tr>
-  </table>
+  
+  <%= render :partial => 'logo_header' %>
 
   <p>
     Dear <%= @user.name.split.first %>,
@@ -19,53 +14,15 @@
     hashtags #DrainHero, #AdoptADrain and #LGROWSewer in your posts.
   </p>
 
-  <!--p>
-    If you encounter medical waste, construction debris, or if the drain is
-    clogged beneath the grate, <a
-    href="http://www.sf311.org/index.aspx?page=127">report to 311</a> to have
-    it cleared by LGROW.
-  </p-->
-
   <p>
     As always, please let us know if you have any feedback or questions about
     this program. We love to hear from you.
   </p>
 
-  <p>
-    Sincerely,
-  </p>
-  <p>
-    <a href="https://adoptadrain-lgrow.org/">Adopt a Drain</a> Team
-    <br />
-    <a href="mailto:hello@citizenlabs.org">hello@citizenlabs.org</a>
-  </p>
+  <%= render :partial => 'signature' %>
 
-  <p>
-    <em>
-      Remember, LGROW, County nor State government won't be held responsible
-      for anything that happens to you or others in service of maintaining your
-      drain. Please be careful.
-    </em>
-  </p>
+  <%= render :partial => 'email_footer' %>
 
-  <p style="font-style: italic; font-size: 11px;">
-    If you move or are no longer able to tend to your drain, please abandon it on
-    <a href="adoptadrain-lgrow.org">https://adoptadrain-lgrow.org</a>. Thank you.
-  </p>
+  <%= render :partial => 'social_media' %>
 
-  <p>
-
-    <a href="https://www.facebook.com/LGROW.org" style="text-decoration:none !important;">
-      <%= image_tag image_url("icons/facebook.png"), :alt => "grbwater facebook", :title => "grbwater facebook" %>
-    </a>
-    &nbsp;
-    <a href="https://twitter.com/LGROW_GVMC" style="text-decoration:none !important;">
-      <%= image_tag image_url("icons/twitter.png"), :alt => "grbwater twitter", :title => "grbwater twitter" %>
-    </a>
-    &nbsp;
-    <a href="https://www.instagram.com/lgrow_org/" style="text-decoration:none !important;">
-      <%= image_tag image_url("icons/instagram.png"), :alt => "grbwater instagram", :title => "grbwater instagram" %>
-    </a>
-
-  </p>
 </td></tr></table>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,8 +9,18 @@ Rails.application.configure do
   config.cache_classes = false
 
   # asset host
-  # config.action_controller.asset_host = 'http://' + Socket.ip_address_list[1].ip_address + ':3000'
-  # config.action_mailer.asset_host = config.action_controller.asset_host
+  config.action_controller.asset_host = Proc.new { |source, request|
+    # source = "/assets/brands/stockholm_logo_horizontal.png"
+    # request = A full-fledged ActionDispatch::Request instance
+
+    # sometimes request is nil and everything breaks
+    scheme = request.try(:scheme).presence || "http"
+    host = request.try(:host).presence || "localhost:3000"
+    port = request.try(:port).presence || nil
+
+    ["#{scheme}://#{host}", port].reject(&:blank?).join(":")
+  }
+  config.action_mailer.asset_host = config.action_controller.asset_host
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -20,8 +30,19 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {host: 'localhost:3000'}
+
+  # Note: if you do this, you need to change your security settings on your google account
+  ActionMailer::Base.smtp_settings = {
+  :address        => 'smtp.gmail.com',
+  :domain         => 'mail.google.com',
+  :port           => 587,
+  :user_name      => 'example@gmail.com',
+  :password       => 'examplePlainTextPassword',
+  :authentication => :plain,
+  :enable_starttls_auto => true
+}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -48,5 +69,5 @@ Rails.application.configure do
 
   # For Mailcatcher
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {address: 'localhost', port: 1025}
+  # config.action_mailer.smtp_settings = {address: 'localhost', port: 1025}
 end

--- a/config/initializers/preview_interceptors.rb
+++ b/config/initializers/preview_interceptors.rb
@@ -1,0 +1,1 @@
+ActionMailer::Base.register_preview_interceptor(ActionMailer::InlinePreviewInterceptor)

--- a/test/mailers/previews/thing_mailer_preview.rb
+++ b/test/mailers/previews/thing_mailer_preview.rb
@@ -1,3 +1,23 @@
 # Preview all emails at http://localhost:3000/rails/mailers/thing_mailer
 class ThingMailerPreview < ActionMailer::Preview
+    
+    def first_adoption_confirmation
+        # Note - for this to work, you must assign a valid user_id to thing id number 1 in the database
+        ThingMailer.first_adoption_confirmation(Thing.first)
+    end
+
+    def second_adoption_confirmation
+        # Note - for this to work, you must assign a valid user_id to thing id number 2 in the database
+        ThingMailer.second_adoption_confirmation(Thing.second)
+    end 
+
+    def third_adoption_confirmation
+        # Note - for this to work, you must assign a valid user_id to thing id number 3 in the database
+        ThingMailer.third_adoption_confirmation(Thing.third)
+    end
+
+    def reminder
+        # Note - for this to work, you must assign a valid user_id to thing id number 1 in the database
+        ThingMailer.reminder(Thing.first)
+    end 
 end

--- a/test/mailers/thing_mailer_test.rb
+++ b/test/mailers/thing_mailer_test.rb
@@ -14,6 +14,27 @@ class ThingMailerTest < ActionMailer::TestCase
     assert_equal 'Thanks for adopting a drain, Erik!', email.subject
   end
 
+  # https://github.com/rails/rails/blob/master/actionmailer/test/base_test.rb
+  test "first_adopted_confirmation inline attachments" do
+    @user = users(:erik)
+    @thing = things(:thing_1)
+    @thing.user = @user
+
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}"))
+
+    email = ThingMailer.first_adoption_confirmation(@thing)
+    assert_nothing_raised { email.message }
+
+    assert_equal ["image/png; filename=adopt-a-drain.png",
+                    "image/png; filename=facebook.png",
+                    "image/png; filename=twitter.png",
+                    "image/png; filename=instagram.png"],
+                email.attachments.inline.map { |a| a["Content-Type"].to_s }
+  end
+
   test 'second_adoption_confirmation' do
     @user = users(:erik)
     @thing = things(:thing_1)
@@ -27,18 +48,60 @@ class ThingMailerTest < ActionMailer::TestCase
     assert_equal 'Thanks for adopting another drain, Erik!', email.subject
   end
 
-  test 'third_adoption_confirmation' do
+  test "second_adopted_confirmation inline attachments" do
     @user = users(:erik)
     @thing = things(:thing_1)
     @thing.user = @user
 
-    email = ThingMailer.third_adoption_confirmation(@thing).deliver_now
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}"))
+    assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}"))
 
-    assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['hello@citizenlabs.org'], email.from
-    assert_equal ['erik@example.com'], email.to
-    assert_equal 'We really do love you, Erik!', email.subject
+    email = ThingMailer.second_adoption_confirmation(@thing)
+    assert_nothing_raised { email.message }
+
+    assert_equal ["image/png; filename=adopt-a-drain.png",
+                    "image/png; filename=facebook.png",
+                    "image/png; filename=twitter.png",
+                    "image/png; filename=instagram.png"],
+                email.attachments.inline.map { |a| a["Content-Type"].to_s }
   end
+
+  # This email unused at this time
+  # test 'third_adoption_confirmation' do
+  #   @user = users(:erik)
+  #   @thing = things(:thing_1)
+  #   @thing.user = @user
+
+  #   email = ThingMailer.third_adoption_confirmation(@thing).deliver_now
+
+  #   assert_not ActionMailer::Base.deliveries.empty?
+  #   assert_equal ['hello@citizenlabs.org'], email.from
+  #   assert_equal ['erik@example.com'], email.to
+  #   assert_equal 'We really do love you, Erik!', email.subject
+  # end
+
+  # This email unused at this time
+  # test "third_adopted_confirmation inline attachments" do
+  #   @user = users(:erik)
+  #   @thing = things(:thing_1)
+  #   @thing.user = @user
+
+  #   assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/logos/adopt-a-drain.png'}"))
+  #   assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/facebook.png'}"))
+  #   assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/twitter.png'}"))
+  #   assert(File.exists?("#{Rails.root.to_s + '/app/assets/images/icons/instagram.png'}"))
+
+  #   email = ThingMailer.third_adoption_confirmation(@thing)
+  #   assert_nothing_raised { email.message }
+
+  #   assert_equal ["image/png; filename=adopt-a-drain.png",
+  #                   "image/png; filename=facebook.png",
+  #                   "image/png; filename=twitter.png",
+  #                   "image/png; filename=instagram.png"],
+  #               email.attachments.inline.map { |a| a["Content-Type"].to_s }
+  # end
 
   test 'thing_update_report' do
     admin1 = users(:admin)


### PR DESCRIPTION
contributes to #75
* fixed broken image links by changing to inline attachments
* fixed a formatting problem due to the size of the logo by adding a CSS style for max-width of 800, per standard email guidelines
* Add ability to preview emails in browser
* Work remaining: Change to inline attachments for remaining emails in thing_mailer.rb