### PR TITLE
Automatically refresh my drains

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -292,6 +292,16 @@ $(function() {
       });
     }
   }
+  /* Ajax call to refresh the list of 'My Drains' in the sidebar */
+  function refreshMyDrains() {
+      $.ajax({
+        type: 'GET',
+        url: '/sidebar/search',
+        success: function(data) {
+          $('#content').html(data);
+        }
+      });
+    }
   function showFlash(type, message) {
     $('#content').prepend(
         $('<div></div>').addClass('alert fade in alert-' + type).data('alert', '').append(
@@ -655,14 +665,7 @@ $(function() {
             setTimeout(function(){ activeMarker.setAnimation(null); }, 2800);
           }
         });
-        /* Refresh the list of 'My Drains' in the sidebar */
-        $.ajax({
-          type: 'GET',
-          url: '/sidebar/search',
-          success: function(data) {
-            $('#content').html(data);
-          }
-        });
+        refreshMyDrains();
       }
     });
     return false;
@@ -689,20 +692,9 @@ $(function() {
           $(submitButton).attr("disabled", false);
         },
         success: function(data) {
-          $.ajax({
-            type: 'GET',
-            url: '/info_window',
-            data: {
-              'thing_id': activeThingId
-            },
-            success: function(data) {
-              activeInfoWindow.close();
-              activeInfoWindow.setContent(data);
-              activeInfoWindow.open(map, activeMarker);
-              activeMarker.setIcon(toSewerMarker);
-              activeMarker.setAnimation(null);
-            }
-          });
+          refreshInfoWindow();
+          refreshMyDrains();
+          activeMarker.setIcon(toSewerMarker);
         }
       });
     }

--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -38,7 +38,7 @@ $(function() {
       handleNoGeolocation(browserSupportFlag);
     });
   }
-  // Browser doesn't support Geolocation
+  // Browser does not support Geolocation
   else {
     browserSupportFlag = false;
     handleNoGeolocation(browserSupportFlag);
@@ -269,6 +269,27 @@ $(function() {
       } else {
         adoptedThings[key][1].setIcon(adoptedMarker);
       }
+    }
+  }
+  /* Ajax call to reopen the 'right' info window for the current state */
+  function refreshInfoWindow() {
+    if (activeThingId == null 
+      || activeThingId === null 
+      || activeThingId === undefined) {
+
+    } else {
+      $.ajax({
+        type: 'GET',
+        url: '/info_window',
+        data: {
+          'thing_id': activeThingId
+        },
+        success: function(data) {
+          activeInfoWindow.close();
+          activeInfoWindow.setContent(data);
+          activeInfoWindow.open(map, activeMarker);
+        }
+      });
     }
   }
   function showFlash(type, message) {
@@ -518,6 +539,7 @@ $(function() {
                 $('.sidebar').addClass('signed-in');
                 $('.sidebar').removeClass('sidebar-full');
                 $('#content').html(data);
+                refreshInfoWindow();
               }
             });
           }
@@ -563,6 +585,7 @@ $(function() {
                 $('#content').html(data);
                 current_user_id = $('#current_user_id').val();
                 flipMarkers();
+                refreshInfoWindow();
               }
             });
           }
@@ -629,6 +652,14 @@ $(function() {
             activeInfoWindow.open(map, activeMarker);
             activeMarker.setIcon(adoptedByYouMarker);
             activeMarker.setAnimation(google.maps.Animation.BOUNCE);
+          }
+        });
+        /* Refresh the list of 'My Drains' in the sidebar */
+        $.ajax({
+          type: 'GET',
+          url: '/sidebar/search',
+          success: function(data) {
+            $('#content').html(data);
           }
         });
       }
@@ -840,6 +871,7 @@ $(function() {
             $('#content').html(data);
           }
         });
+        refreshInfoWindow();
       }
     });
     return false;
@@ -854,9 +886,7 @@ $(function() {
         $(submitButton).attr("disabled", false);
       },
       success: function(data) {
-        activeInfoWindow.close();
-        activeInfoWindow.setContent(data);
-        activeInfoWindow.open(map, activeMarker);
+        refreshInfoWindow();
       }
     });
     return false;

--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -864,9 +864,14 @@ $(function() {
             $('#content').html(data);
           }
         });
-        refreshInfoWindow();
-      }
-    });
+      },
+    }).done(function() {
+      // refreshInfoWindow(); This is unneeded because of the window refresh below
+      // This is a hack to get around the Rails token being invalid.
+      // Maybe a Ruby expert could fix the actual problem
+      window.location.reload(false); 
+     })
+    ;
     return false;
   });
   $('.sidebar').on('submit','#sign_out_form', function() {

--- a/app/models/thing.rb
+++ b/app/models/thing.rb
@@ -31,6 +31,7 @@ class Thing < ActiveRecord::Base
     find_by_sql([query, lat.to_f, lng.to_f, lat.to_f, limit.to_i])
   end
 
+  # People get to name their drains
   def display_name
     (adopted? ? adopted_name : name) || ''
   end


### PR DESCRIPTION
Contributes to #106 and #132 

### Refresh Drain's info window
1. When a user signs up
2. When a user logs in
3. When a user logs out
4. When one of these actions is done twice in a row. 

### Refresh My Drains list
* When a drain is adopted
* When a drain is abandoned

Note: #4 is broken right now. When you do two of the actions one right after the other, I get the error below
<img width="709" alt="screen shot 2019-03-04 at 10 33 37 pm" src="https://user-images.githubusercontent.com/39837332/53780123-e5bd0300-3ed0-11e9-9d0e-8b995ad1f377.png">
